### PR TITLE
Added network hashrate estimate

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -80,6 +80,8 @@ var (
 		Name: "consensus_height", Help: "Consensus block height"})
 	consensusDifficulty = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "consensus_difficulty", Help: "Consensus difficulty"})
+	consensusHshrt = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "consensus_hashrate", Help: "Consensus hashrate"})
 
 	// Daemon Metrics
 	//	daemonAggregateNumAlerts = promauto.NewGauge(prometheus.GaugeOpts{
@@ -303,6 +305,7 @@ func consensusMetrics(sc *sia.Client) {
 	consensusHeight.Set(float64(cs.Height))
 	Difficulty, _ := cs.Difficulty.Float64()
 	consensusDifficulty.Set(Difficulty)
+	consensusHshrt.Set(Difficulty/600.0)
 }
 
 // daemonMetrics retrieves and sets the Prometheus metrics related to the


### PR DESCRIPTION
Divide block difficulty by 600 (target block time in seconds) for estimate of network hashrate.